### PR TITLE
Fixed parsing of fleetctl status. There is now a new STATE column.

### DIFF
--- a/client_cli_status.go
+++ b/client_cli_status.go
@@ -9,6 +9,9 @@ import (
 )
 
 const (
+	STATUS_LAUNCHED = "launched"
+	STATUS_INACTIVE = "inactive"
+
 	LOAD_UNKNOWN = "-"
 	LOAD_LOADED  = "loaded"
 
@@ -24,6 +27,9 @@ const (
 type UnitStatus struct {
 	// Unit Name with file extension
 	Unit string
+
+	// Fleet state, "launched" or "inactive"
+	State string
 
 	// "-", "loaded"
 	Load string
@@ -76,11 +82,12 @@ func parseFleetStatusOutput(output string) ([]UnitStatus, error) {
 		words := filterEmpty(strings.Split(line, "\t"))
 		unitStatus := UnitStatus{
 			Unit:        words[0],
-			Load:        words[1],
-			Active:      words[2],
-			Sub:         words[3],
-			Description: words[4],
-			Machine:     words[5],
+			State:       words[1],
+			Load:        words[2],
+			Active:      words[3],
+			Sub:         words[4],
+			Description: words[5],
+			Machine:     words[6],
 		}
 		result = append(result, unitStatus)
 	}

--- a/client_cli_status_test.go
+++ b/client_cli_status_test.go
@@ -4,71 +4,86 @@ import (
 	"testing"
 )
 
-func TestParser(t *testing.T) {
-	output := `UNIT						LOAD	ACTIVE	SUB	DESC							MACHINE
-1de9403c-2592-4b01-af17-6e7f06ae05de.service	-	-	-	stm-session-service Sidekick				-
-2ecf3fc0-b541-41ce-85b9-4958e5e30e1c.service	loaded	active	running	stm-session-redis Service				f715c360.../172.17.8.103
-3eb35412-7999-48b7-a545-3f28e5245105.service	loaded	active	running	stm-api-service:stm-session-service Ambassador		f715c360.../172.17.8.103
-52468430-9c81-4bec-9cc0-e144b6377d59.service	loaded	active	running	stm-api-redis Sidekick					f715c360.../172.17.8.103
-5a42cf23-773d-4303-932f-a226a0f6b3a4.service	loaded	active	running	stm-api-redis Service					f715c360.../172.17.8.103
-71f3a18b-316b-475d-bc28-49e374c255cf.service	loaded	active	running	stm-api-redis Sidekick					f715c360.../172.17.8.103
-7b1a73fa-5991-4671-be8a-662ce9c5c211.service	loaded	active	running	stm-api-service Service					f715c360.../172.17.8.103
-8451b50e-4cda-4baf-8b33-f9f579a44912.service	loaded	active	running	stm-api-redis Service					f715c360.../172.17.8.103
-b99917a1-48ac-4d16-8fc1-45127d323cfe.service	loaded	active	running	stm-session-service:stm-session-redis Ambassador	f715c360.../172.17.8.103
-cca374f0-6eef-4547-a80b-1762fc3e3118.service	loaded	active	running	stm-session-redis Sidekick				f715c360.../172.17.8.103
-e82a5ab7-e388-4394-b51f-88c118e89780.service	loaded	failed	failed	stm-session-service Service				f715c360.../172.17.8.103
-fc80556b-0f2a-46bf-b580-76d2228cb5bd.service	loaded	active	running	stm-api-service:stm-api-redis Ambassador		f715c360.../172.17.8.103
+const (
+	OUTPUT_1 = `UNIT						STATE		LOAD	ACTIVE	SUB	DESC				MACHINE
+13d1395a-65fd-47c8-8d80-4d31da4499f6.service	inactive	-	-	-	Presence redis Service		-
+0c4f0407-b5f8-4a6d-9b8b-0172db5b105f.service	launched	loaded	active	running	Ambassador api:redis Ambassador	26f4636c.../172.17.8.101
+2703648d-6b45-4d74-9e15-7c0de5c63ed1.service	launched	loaded	active	running	Presence api Service		26f4636c.../172.17.8.101
+3d29c681-014e-433c-952c-590a83c1d1e7.service	launched	loaded	active	exited	Storage redis Storage		26f4636c.../172.17.8.101
+6e301e0f-75c7-44d3-b0fe-e7f6787ef4b3.service	launched	loaded	active	running	Presence redis Service		26f4636c.../172.17.8.101
+de3f0ecd-68b8-47ad-9265-96275e25fd1e.service	launched	loaded	active	running	User api Service		26f4636c.../172.17.8.101
+df7df57f-f6ca-4c10-bcfa-b5164baff5a3.service	launched	loaded	active	running	User redis Service		26f4636c.../172.17.8.101
 `
-	status, err := parseFleetStatusOutput(output)
+)
+
+func AssertStatusParsedAs(t *testing.T, status UnitStatus,
+	expectedUnitName, expectedState, expectedLoad, expectedActive,
+	expectedSub, expectedDesc, expectedMachine, expectedMachineIP string) {
+	if status.Unit != expectedUnitName {
+		t.Fatalf("Unexpected unit name: %s", status.Unit)
+	}
+	if status.State != expectedState {
+		t.Fatalf("Unexpected state: %s, expected: %s", status.State, expectedState)
+	}
+	if status.Load != expectedLoad {
+		t.Fatalf("Unexpected unit name: %s", status.Load)
+	}
+	if status.Active != expectedActive {
+		t.Fatalf("Unexpected unit name: %s", status.Active)
+	}
+	if status.Sub != expectedSub {
+		t.Fatalf("Unexpected unit name: %s", status.Sub)
+	}
+	if status.Description != expectedDesc {
+		t.Fatalf("Unexpected description: %s", status.Description)
+	}
+	if status.Machine != expectedMachine {
+		t.Fatalf("Unexpected machine: %s", status.Machine)
+	}
+	if status.MachineIP() != expectedMachineIP {
+		t.Fatalf("Unexpected IP: %s", status.MachineIP())
+	}
+}
+
+func TestParser__OUTPUT_1(t *testing.T) {
+	status, err := parseFleetStatusOutput(OUTPUT_1)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	if len(status) != 12 {
-		t.Fatalf("Invalid number of status objects returned, expected 12, got: %d", len(status))
+	if len(status) != 7 {
+		t.Fatalf("Invalid number of status objects returned, expected 7, got: %d", len(status))
 	}
-
-	testUnit := func(status UnitStatus, expectedUnitName, expectedLoad, expectedActive, expectedSub, expectedDesc, expectedMachine, expectedMachineIP string) {
-		if status.Unit != expectedUnitName {
-			t.Fatalf("Unexpected unit name: %s", status.Unit)
-		}
-		if status.Load != expectedLoad {
-			t.Fatalf("Unexpected unit name: %s", status.Load)
-		}
-		if status.Active != expectedActive {
-			t.Fatalf("Unexpected unit name: %s", status.Active)
-		}
-		if status.Sub != expectedSub {
-			t.Fatalf("Unexpected unit name: %s", status.Sub)
-		}
-		if status.Description != expectedDesc {
-			t.Fatalf("Unexpected description: %s", status.Description)
-		}
-		if status.Machine != expectedMachine {
-			t.Fatalf("Unexpected machine: %s", status.Machine)
-		}
-		if status.MachineIP() != expectedMachineIP {
-			t.Fatalf("Unexpected IP: %s", status.MachineIP())
-		}
-	}
-
-	testUnit(
+	AssertStatusParsedAs(t,
 		status[0],
-		"1de9403c-2592-4b01-af17-6e7f06ae05de.service",
+		"13d1395a-65fd-47c8-8d80-4d31da4499f6.service",
+		"inactive",
 		"-",
 		"-",
 		"-",
-		"stm-session-service Sidekick",
+		"Presence redis Service",
 		"-",
 		"",
 	)
-	testUnit(
-		status[6],
-		"7b1a73fa-5991-4671-be8a-662ce9c5c211.service",
+	AssertStatusParsedAs(t,
+		status[2],
+		"2703648d-6b45-4d74-9e15-7c0de5c63ed1.service",
+		"launched",
 		"loaded",
 		"active",
 		"running",
-		"stm-api-service Service",
-		"f715c360.../172.17.8.103",
-		"172.17.8.103",
+		"Presence api Service",
+		"26f4636c.../172.17.8.101",
+		"172.17.8.101",
+	)
+	AssertStatusParsedAs(t,
+		status[3],
+		"3d29c681-014e-433c-952c-590a83c1d1e7.service",
+		"launched",
+		"loaded",
+		"active",
+		"exited",
+		"Storage redis Storage",
+		"26f4636c.../172.17.8.101",
+		"172.17.8.101",
 	)
 }


### PR DESCRIPTION
This adds support to parse `fleetctl status` output with the new STATE column. This is backward incompatible.

I also fixed the tests up a bit. Sorry for the diff mess.
