### PR TITLE
Fix api changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_PATH := $(shell pwd)/.gobuild
 
 D0_PATH := "$(BUILD_PATH)/src/$(PARENT_PACKAGE)"
 
-.PHONY=clean run-test get-deps update-deps fmt run-tests examples library
+.PHONY=clean run-test get-deps update-deps fmt run-tests examples
 
 GOPATH := $(BUILD_PATH)
 
@@ -21,7 +21,7 @@ ARCH=$(shell go env GOARCH)
 
 # === Top Level Targets ==============================
 
-all: get-deps library examples
+all: get-deps examples
 
 clean:
 	rm -rf $(BUILD_PATH) examples/bin/
@@ -42,13 +42,6 @@ get-deps: .gobuild
 	#
 	# Fetch public dependencies via `go get`
 	GOPATH=$(GOPATH) go get -d -v $(PROJECT_PACKAGE)
-
-
-## -- library ---------------------------------------------
-library: $(BUILD_PATH)/pkg/$(OS)_$(ARCH)/$(PARENT_PACKAGE)/fleet-client-go.a
-
-$(BUILD_PATH)/pkg/$(OS)_$(ARCH)/$(PARENT_PACKAGE)/fleet-client-go.a: $(SOURCE)
-	cd $(GOPATH); GOPATH=$(GOPATH) go install -a $(PROJECT_PACKAGE)
 
 ## -- examples ---------------------------------------------
 examples: examples/bin/cli examples/bin/status

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ there is no ssh connection used, the possible commands are `submit`, `start`,
 version of `Status`, that uses `list-units` and just parses whether a service
 is running or not.
 
-A new way to use fleets http api has been implemented. 
+A new way to use fleets http api has been implemented.
 
 ## install
 ```go
@@ -15,26 +15,31 @@ import fleetClientPkg "github.com/catalyst-zero/fleet-client-go"
 
 ## usage
 ```go
-// Create new fleet client.
-fleetClient := fleetClientPkg.NewClient()
+// Create new fleet client based on a given binary.
+fleetClient := fleetClientPkg.NewClientCLI()
 
-// Submit unit file.
-unitFilePath := "/tmp/unit-files/hello-world.service"
-err := fleetClient.Submit(unitFilePath)
+// Create new fleet client based on the http api.
+fleetClient := fleetClientPkg.NewClientAPI()
 
-// Start a unit.
-unitFileName := "hello-world.service"
-err := fleetClient.Start(unitFileName)
+// Interface methods.
+type FleetClient interface {
+  // A Unit is a submitted job known by fleet, but not started yet. Submitting
+  // a job creates a unit. Unit() returns such an object. Further a Unit has
+  // different properties than a ScheduledUnit.
+	Unit(name string) (*job.Unit, error)
 
-// Stop a unit.
-unitFileName := "hello-world.service"
-err := fleetClient.Stop(unitFileName)
+  // A ScheduledUnit is a submitted job known by fleet in a specific state.
+  // ScheduledUnit() does not fetch a ScheduledUnit if a Unit is not started
+  // yet, but only submitted. Further a ScheduledUnit has different properties
+  // than a Unit.
+	ScheduledUnit(name string) (*job.ScheduledUnit, error)
 
-// Destroy a unit.
-unitFileName := "hello-world.service"
-err := fleetClient.Destroy(unitFileName)
-
-// Get status of a unit.
-unitFileName := "hello-world.service"
-status, err := fleetClient.Status(unitFileName)
-fmt.Printf("%#v\n", status.Running) // bool
+	Submit(name, filePath string) error
+	Start(name string) error
+	Stop(name string) error
+	Load(name string) error
+	Destroy(name string) error
+	Status(name string) (*Status, error) // Deprecated, use StatusUnit()
+	StatusUnit(name string) (UnitStatus, error)
+}
+```

--- a/client.go
+++ b/client.go
@@ -58,7 +58,8 @@ type Status struct {
 }
 
 type FleetClient interface {
-	Get(name string) (*job.Job, error)
+	Unit(name string) (*job.Unit, error)
+	ScheduledUnit(name string) (*job.ScheduledUnit, error)
 	Submit(name, filePath string) error
 	Start(name string) error
 	Stop(name string) error

--- a/client.go
+++ b/client.go
@@ -58,8 +58,17 @@ type Status struct {
 }
 
 type FleetClient interface {
+	// A Unit is a submitted job known by fleet, but not started yet. Submitting
+	// a job creates a unit. Unit() returns such an object. Further a Unit has
+	// different properties than a ScheduledUnit.
 	Unit(name string) (*job.Unit, error)
+
+	// A ScheduledUnit is a submitted job known by fleet in a specific state.
+	// ScheduledUnit() does not fetch a ScheduledUnit if a Unit is not started
+	// yet, but only submitted. Further a ScheduledUnit has different properties
+	// than a Unit.
 	ScheduledUnit(name string) (*job.ScheduledUnit, error)
+
 	Submit(name, filePath string) error
 	Start(name string) error
 	Stop(name string) error

--- a/client_api.go
+++ b/client_api.go
@@ -45,13 +45,13 @@ func NewClientAPIWithSocket(socket string) FleetClient {
 
 // getUnitFromFile attempts to load a Unit from a given filename
 // It returns the Unit or nil, and any error encountered
-func getUnitFromFile(file string) (*unit.Unit, error) {
+func getUnitFromFile(file string) (*unit.UnitFile, error) {
 	out, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}
 
-	return unit.NewUnit(string(out))
+	return unit.NewUnitFile(string(out))
 }
 
 func (this *ClientAPI) Submit(name, filePath string) error {
@@ -69,56 +69,66 @@ func (this *ClientAPI) Submit(name, filePath string) error {
 	return nil
 }
 
-func (this *ClientAPI) Get(name string) (*job.Job, error) {
-	j, err := this.client.Job(name)
+func (this *ClientAPI) ScheduledUnit(name string) (*job.ScheduledUnit, error) {
+	su, err := this.client.ScheduledUnit(name)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving Job(%s) from Registry: %v", name, err)
-	} else if j == nil {
-		return nil, fmt.Errorf("unable to find Job(%s)", name)
+		return nil, fmt.Errorf("error retrieving ScheduledUnit (%s) from Registry: %v", name, err)
+	} else if su == nil {
+		return nil, fmt.Errorf("unable to find ScheduledUnit (%s)", name)
 	}
-	return j, nil
+	return su, nil
+}
+
+func (this *ClientAPI) Unit(name string) (*job.Unit, error) {
+	u, err := this.client.Unit(name)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Unit (%s) from Registry: %v", name, err)
+	} else if u == nil {
+		return nil, fmt.Errorf("unable to find Unit (%s)", name)
+	}
+	return u, nil
 }
 
 func (this *ClientAPI) Start(name string) error {
-	j, err := this.Get(name)
+	u, err := this.Unit(name)
 
 	if err != nil {
 		return errgo.Mask(err)
 	}
-	this.client.SetJobTargetState(j.Name, job.JobStateLaunched)
+	this.client.SetJobTargetState(u.Name, job.JobStateLaunched)
 
 	return nil
 }
 
 func (this *ClientAPI) Stop(name string) error {
-	j, err := this.Get(name)
+	u, err := this.Unit(name)
 
 	if err != nil {
 		return errgo.Mask(err)
 	}
-	this.client.SetJobTargetState(j.Name, job.JobStateLoaded)
+	this.client.SetJobTargetState(u.Name, job.JobStateLoaded)
 
 	return nil
 }
 
 func (this *ClientAPI) Load(name string) error {
-	j, err := this.Get(name)
+	u, err := this.Unit(name)
 
 	if err != nil {
 		return errgo.Mask(err)
 	}
-	this.client.SetJobTargetState(j.Name, job.JobStateLoaded)
+	this.client.SetJobTargetState(u.Name, job.JobStateLoaded)
 
 	return nil
 }
 
 func (this *ClientAPI) Destroy(name string) error {
-	j, err := this.Get(name)
+	u, err := this.Unit(name)
 
 	if err != nil {
 		return errgo.Mask(err)
 	}
-	this.client.DestroyJob(j.Name)
+	this.client.DestroyJob(u.Name)
 
 	return nil
 }
@@ -128,37 +138,70 @@ func (this *ClientAPI) Status(name string) (*Status, error) {
 }
 
 func (this *ClientAPI) StatusUnit(name string) (UnitStatus, error) {
-	j, err := this.Get(name)
-
+  // Get unit state.
+  unitState, err := this.unitState(name)
 	if err != nil {
 		return UnitStatus{}, errgo.Mask(err)
+	}
+
+	// Get machine ip.
+  ip, err := this.getMachineIp(name)
+	if err != nil {
+		return UnitStatus{}, errgo.Mask(err)
+	}
+
+  // Get unit.
+  u, err := this.client.Unit(name)
+	if err != nil {
+		return UnitStatus{}, errgo.Mask(err)
+	}
+
+	return UnitStatus{
+		Unit:   u.Name,
+		State:  string(u.TargetState),
+		Load:   unitState.LoadState,
+		Active: unitState.ActiveState,
+		Sub:    unitState.SubState,
+
+		Description: u.Unit.Description(),
+
+		Machine: ip,
+	}, nil
+}
+
+func (this *ClientAPI) unitState(unitName string) (unit.UnitState, error) {
+  unitStates, err := this.client.UnitStates()
+	if err != nil {
+		return unit.UnitState{}, errgo.Mask(err)
+	}
+
+  state := &unit.UnitState{}
+  for _, unitState := range unitStates {
+    if unitState.UnitName == unitName {
+      state = unitState
+    }
+  }
+
+  return *state, nil
+}
+
+func (this *ClientAPI) getMachineIp(unitName string) (string, error) {
+  su, err := this.client.ScheduledUnit(unitName)
+	if err != nil {
+		return "", errgo.Mask(err)
 	}
 
 	machines, err := this.client.Machines()
 	if err != nil {
-		return UnitStatus{}, errgo.Mask(err)
+		return "", errgo.Mask(err)
 	}
 
 	ip := ""
 	for _, machine := range machines {
-		if machine.ID == j.UnitState.MachineID {
+		if machine.ID == su.TargetMachineID {
 			ip = machine.PublicIP
 		}
 	}
 
-	description := ""
-	for _, s := range j.Unit.Contents["Unit"]["Description"] {
-		description = s
-	}
-	return UnitStatus{
-		Unit:   j.Name,
-		State:  string(*j.State),
-		Load:   j.UnitState.LoadState,
-		Active: j.UnitState.ActiveState,
-		Sub:    j.UnitState.SubState,
-
-		Description: description,
-
-		Machine: ip,
-	}, nil
+  return GetMachineIP(ip), nil
 }

--- a/client_api.go
+++ b/client_api.go
@@ -138,20 +138,20 @@ func (this *ClientAPI) Status(name string) (*Status, error) {
 }
 
 func (this *ClientAPI) StatusUnit(name string) (UnitStatus, error) {
-  // Get unit state.
-  unitState, err := this.unitState(name)
+	// Get unit state.
+	unitState, err := this.unitState(name)
 	if err != nil {
 		return UnitStatus{}, errgo.Mask(err)
 	}
 
 	// Get machine ip.
-  ip, err := this.getMachineIp(name)
+	ip, err := this.getMachineIp(name)
 	if err != nil {
 		return UnitStatus{}, errgo.Mask(err)
 	}
 
-  // Get unit.
-  u, err := this.client.Unit(name)
+	// Get unit.
+	u, err := this.client.Unit(name)
 	if err != nil {
 		return UnitStatus{}, errgo.Mask(err)
 	}
@@ -170,23 +170,23 @@ func (this *ClientAPI) StatusUnit(name string) (UnitStatus, error) {
 }
 
 func (this *ClientAPI) unitState(unitName string) (unit.UnitState, error) {
-  unitStates, err := this.client.UnitStates()
+	unitStates, err := this.client.UnitStates()
 	if err != nil {
 		return unit.UnitState{}, errgo.Mask(err)
 	}
 
-  state := &unit.UnitState{}
-  for _, unitState := range unitStates {
-    if unitState.UnitName == unitName {
-      state = unitState
-    }
-  }
+	state := &unit.UnitState{}
+	for _, unitState := range unitStates {
+		if unitState.UnitName == unitName {
+			state = unitState
+		}
+	}
 
-  return *state, nil
+	return *state, nil
 }
 
 func (this *ClientAPI) getMachineIp(unitName string) (string, error) {
-  su, err := this.client.ScheduledUnit(unitName)
+	su, err := this.client.ScheduledUnit(unitName)
 	if err != nil {
 		return "", errgo.Mask(err)
 	}
@@ -203,5 +203,5 @@ func (this *ClientAPI) getMachineIp(unitName string) (string, error) {
 		}
 	}
 
-  return GetMachineIP(ip), nil
+	return GetMachineIP(ip), nil
 }

--- a/client_cli.go
+++ b/client_cli.go
@@ -39,8 +39,12 @@ func (this *ClientCLI) Submit(name, filePath string) error {
 	return nil
 }
 
-func (this *ClientCLI) Get(name string) (*job.Job, error) {
-	return nil, fmt.Errorf("Method not implemented: ClientCLI.Get")
+func (this *ClientCLI) ScheduledUnit(name string) (*job.ScheduledUnit, error) {
+	return nil, fmt.Errorf("Method not implemented: ClientCLI.ScheduledUnit")
+}
+
+func (this *ClientCLI) Unit(name string) (*job.Unit, error) {
+	return nil, fmt.Errorf("Method not implemented: ClientCLI.Unit")
 }
 
 func (this *ClientCLI) Start(name string) error {

--- a/examples/cli/cli.go
+++ b/examples/cli/cli.go
@@ -8,6 +8,6 @@ import (
 func main() {
 	cAPI := client.NewClientAPI()
 
-	j, err := cAPI.Get("app.service")
-	fmt.Println(j, err)
+	u, err := cAPI.Unit("app.service")
+	fmt.Println(u, err)
 }


### PR DESCRIPTION
Due to recent changes in fleet our client was broken.
### changes
- it is no longer possible to fetch a `Job` object
- now there are `Unit` and `Scheduled` objects available, each with different properties
- all states now needs to be fetched at once, one needs to pick the desired state
- simplified makefile, I got errors like the following

``` bash
/fleet-client-go $ make
...
go install runtime: open /usr/local/go/pkg/linux_amd64/runtime.a: permission denied
...
```
